### PR TITLE
Fix product feature spec to check next product

### DIFF
--- a/spec/features/product_feature_spec.rb
+++ b/spec/features/product_feature_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Products", type: :feature do
     visit product_path(p1)
     expect(page).to have_content p1.name
     click_link "Next Product"
-    expect(page).not_to have_content p2.name
+    expect(page).to have_content p2.name
   end
 
   it 'loads next product without page refresh', js: true do


### PR DESCRIPTION
In product_feature_spec.rb (line 15), we should expect the page to have the name of the next product, not to not have it. See Issue [#14](https://github.com/learn-co-curriculum/diy-json-serializer-lab/issues/14)